### PR TITLE
Add Travis CI build instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: false
+language: erlang
+script: make check INCLUDE='-I${_KERL_ACTIVE_DIR}/usr/include' PROVEFLAGS=-v
+otp_release:
+  - 17.5
+  - 18.1
+  - 18.2
+addons:
+  apt:
+    packages:
+      - ragel
+      - lemon

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,14 @@
 .PHONY: clean all check
 
-CC := gcc
-CFLAGS := -MMD -Wall -Wextra -pedantic -ggdb -fms-extensions -rdynamic
-PARSE_CFLAGS := -MMD -Wall -Wextra -Wno-unused-variable -Wno-unused-parameter -Wno-sign-compare -ggdb
-LDFLAGS := -ldl
-RAGEL := ragel
-RAGELFLAGS := -G2
-LEMON := lemon
+CC ?= gcc
+CFLAGS ?= -MMD -std=gnu99 -Wall -Wextra -ggdb -fms-extensions -rdynamic
+CFLAGS := $(CFLAGS) $(INCLUDE)
+PARSE_CFLAGS := $(CFLAGS) -Wno-unused-variable -Wno-unused-parameter -Wno-sign-compare
+LDFLAGS ?= -ldl
+RAGEL ?= ragel
+RAGELFLAGS ?= -G2
+LEMON ?= lemon
+PROVEFLAGS ?=
 
 NIFFY_OBJS = main.o nif_stubs.o lex.o parse.o atom.o str.o variable.o map.o
 OBJS = $(NIFFY_OBJS)
@@ -36,6 +38,6 @@ clean:
 	$(RM) $(OBJS) $(OBJS:.o=.d) $(GENERATED) lex.t niffy
 
 check: lex_test parse_test
-	prove
+	prove $(PROVEFLAGS)
 
 -include $(OBJS:.o=.d)


### PR DESCRIPTION
We also tweak our flags for Travis.  The default C compiler is ancient so forget about just setting -std=gnu11.  We'll live with the remaining warnings for now.

We don't support any releases older than 17.0 because we provide some map stubs.  It wouldn't be hard to conditionalize this but I'll wait for someone to complain.
