### PR TITLE
Keep better track of allocations

### DIFF
--- a/atom.c
+++ b/atom.c
@@ -29,6 +29,16 @@ static void init(void)
 }
 
 
+__attribute__((destructor))
+static void shutdown(void)
+{
+    free(table);
+    for (unsigned i = 1; i <= n_entries; ++i)
+        str_free((struct str **)&string_of_atom[i]);
+    free(string_of_atom);
+}
+
+
 static hash hash_of_string(const struct str *s)
 {
     hash v = 0;
@@ -96,8 +106,10 @@ atom intern(const struct str *name)
 {
     hash h = hash_of_string(name);
     atom sym = lookup(name, h);
-    if (sym != 0)
+    if (sym != 0) {
+        str_free((struct str **)&name);
         return sym;
+    }
     sym = ++symbol_counter;
     insert(name, h, sym);
     return sym;

--- a/lex.h
+++ b/lex.h
@@ -41,3 +41,4 @@ struct lexer {                  /* private */
 extern void lex_init(struct lexer *);
 extern void lex_setup_next_line(struct lexer *, char *, bool);
 extern bool lex(struct lexer *, struct token *);
+extern void destroy_token(struct token *token);

--- a/lex.rl
+++ b/lex.rl
@@ -1,5 +1,5 @@
 /*
- *
+ * Lexer for Erlang terms.
  */
 
 #include <assert.h>
@@ -82,6 +82,8 @@ int_literal =
   %{ if (state->i.negate_p) state->i.value = -state->i.value; }
   ;
 
+# There is a leak here, on erroneous input; we could use a local error
+# state to free these strings here and below under those conditions.
 string_literal =
   '"' >{ token->string_value = str_new(0); }
   (( (escaped_char $1 %0)
@@ -183,4 +185,11 @@ bool lex(struct lexer *state, struct token *token)
     /* p == pe when we need more data; we could be in the middle of a
      * token, though. */
     return state->p < state->pe;
+}
+
+
+void destroy_token(struct token *token)
+{
+    if (TOK_STRING == token->type && token->string_value)
+        str_free(&token->string_value);
 }

--- a/lex_test.c
+++ b/lex_test.c
@@ -45,6 +45,7 @@ static bool print_token(void *data, struct token *tk)
     return true;
 }
 
+
 /* read terms from stdin, print token information to stdout */
 int main(void)
 {
@@ -61,6 +62,7 @@ int main(void)
 
         while (lex(&lexer, &token)) {
             print_token(stdout, &token);
+            destroy_token(&token);
         }
     }
     free(line);

--- a/main.c
+++ b/main.c
@@ -67,7 +67,7 @@ static term call(struct function_call *call)
 {
     struct enif_environment_t *m = map_lookup(&modules, call->module);
     assert(NULL != m);
-    term tuple = tuple_of_list(call->args);
+    term tuple = tuple_of_list(NULL, call->args);
     unsigned arity;
     const term *p;
     assert(enif_get_tuple(NULL, tuple, (int *)&arity, &p));

--- a/nif_stubs.h
+++ b/nif_stubs.h
@@ -8,6 +8,11 @@
 
 typedef ERL_NIF_TERM term;
 
+struct alloc {
+    void *p;
+    struct alloc *next;
+};
+
 /* This should be called struct shared_object, but the way erl_nif.h
  * is written forces me to use this dumb name (which should not have a
  * trailing _t, and should be a typedef). */
@@ -19,6 +24,7 @@ struct enif_environment_t {
     void *priv_data;
     term exception;
     struct atom_ptr_map fns;
+    struct alloc *allocations;
 };
 
 typedef enum {
@@ -38,8 +44,8 @@ typedef enum {
 
 /* helpers */
 extern void term_pretty_print(FILE *, const term *);
-void pretty_print_argument_list(FILE *out, const term *p);
-term tuple_of_list(term head);
+void pretty_print_argument_list(FILE *, const term *);
+term tuple_of_list(ErlNifEnv *, term);
 extern bool nconc(term, term);
 extern term iolist_to_binary(term);
 extern term_type type_of_term(const term);

--- a/parse.y
+++ b/parse.y
@@ -100,7 +100,7 @@ bit_type ::= ATOM.
 bit_type ::= ATOM COLON INTEGER.
 
 tuple(T) ::= LBRACE RBRACE. { T = enif_make_tuple(NULL, 0); }
-tuple(T) ::= LBRACE terms(L) RBRACE. { T = tuple_of_list(L); }
+tuple(T) ::= LBRACE terms(L) RBRACE. { T = tuple_of_list(NULL, L); }
 
 term(T) ::= atomic(A). { T = A; }
 term(T) ::= tuple(A). { T = A; }

--- a/parse.y
+++ b/parse.y
@@ -13,8 +13,10 @@
 %extra_argument {callback cb}
 
 %default_type {term}
+
 %token_type {struct token}
 %token_prefix TOK_
+%token_destructor { destroy_token(&$$); }
 
 statements ::= statement.
 
@@ -114,9 +116,11 @@ atomic(A) ::= strings(S). { A = S; }
 
 strings(S) ::= STRING(T). {
     S = enif_make_string_len(NULL, T.string_value->data, T.string_value->len, ERL_NIF_LATIN1);
+    destroy_token(&T);
 }
 strings(S) ::= STRING(H) strings(T). {
     S = enif_make_string_len(NULL, H.string_value->data, H.string_value->len, ERL_NIF_LATIN1);
+    destroy_token(&H);
     assert(nconc(S, T));
 }
 

--- a/str.c
+++ b/str.c
@@ -24,6 +24,7 @@ struct str *str_dup_cstr(const char *s)
 
 void str_free(struct str **p)
 {
+    if (NULL == *p) return;
     (*p)->avail = (*p)->len = 0;
     free(*p);
     *p = NULL;


### PR DESCRIPTION
We make no promises to do a good job of managing memory — niffy runs are expected to be short-lived.  However, keeping track of all the allocations makes it easier to tell with valgrind whether the NIF itself leaks.

Note that there is still work to be done here; for example, when this is done, this should interact with `enif_release_resource` and so on.
