### PR TITLE
Add byte_size/1, element/2, move assert functions out of niffy module

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ Note that the NIF's `load` function will not be called unless you
 explicitly call `niffy:load_nif(nif_name, [])`.  (You don't need to
 call this if your NIF doesn't have a load callback.)
 
+Erlang BIFs available in niffy:
+
+- `niffy:load_nif/2`
+- `niffy:halt/0`
+- `niffy:byte_size/1`
+- `niffy:element/2`
+
 ### Multiple NIFs and other libraries
 
 You can specify several SOs on the command-line, all of which will be

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ However, you probably want more control over the representation fed to
 your NIF, in which case you can modify `fuzz_skeleton.c` to accept
 input as appropriate for your NIF.
 
-For extremely rudimentary property testing, the `niffy:assert_eq/2` and
-`niffy:assert_ne/2` functions are provided, which `abort` on assertion
+For extremely rudimentary property testing, the `assert:eq/2` and
+`assert:ne/2` functions are provided, which `abort` on assertion
 failure.
 
 **Warning:** If your NIF does not load without the `--lazy` option to

--- a/fuzz_skeleton.c
+++ b/fuzz_skeleton.c
@@ -30,6 +30,7 @@ int main(int argc, char **argv)
         return 1;
     }
     niffy_construct_erlang_env();
+    niffy_construct_assert_env();
     /* Beware!  In a (well-meaning) attempt to speed up fuzzing,
      * afl-fuzz by default sets LD_BIND_NOW which will override this
      * RTLD_LAZY; if your NIF uses any functions that aren't implement

--- a/main.c
+++ b/main.c
@@ -72,6 +72,7 @@ int main(int argc, char **argv)
     assert(n_sos > 0);
 
     niffy_construct_erlang_env();
+    niffy_construct_assert_env();
 
     for (int so_idx = 0; so_idx < n_sos && optind < argc; ++so_idx, ++optind) {
         if (!niffy_load_so(argv[optind], rtld_mode, verbosity))

--- a/niffy.c
+++ b/niffy.c
@@ -49,6 +49,22 @@ static term bif_load_nif(ErlNifEnv *env, int argc, const term argv[])
 }
 
 
+static term bif_element(ErlNifEnv *env, int UNUSED, const term argv[])
+{
+    int index, arity;
+    const term *array;
+    if (!enif_get_int(env, argv[0], &index))
+        return enif_make_badarg(env);
+    if (!enif_get_tuple(env, argv[1], &arity, &array))
+        return enif_make_badarg(env);
+
+    if (index < 1 || index > arity)
+        return enif_make_badarg(env);
+
+    return array[index - 1];
+}
+
+
 static term bif_assert_eq(ErlNifEnv *UNUSED, int UNUSED, const term argv[])
 {
     if (enif_is_identical(argv[0], argv[1]))
@@ -144,6 +160,7 @@ void niffy_construct_erlang_env(void)
     assert(map_insert(&modules, intern_cstr(e->entry->name), e));
 
     assert(add_fn(&e->fns, "load_nif", (struct fptr){.arity = 2, .fptr = bif_load_nif}));
+    assert(add_fn(&e->fns, "element", (struct fptr){.arity = 2, .fptr = bif_element}));
     assert(add_fn(&e->fns, "assert_eq", (struct fptr){.arity = 2, .fptr = bif_assert_eq}));
     assert(add_fn(&e->fns, "assert_ne", (struct fptr){.arity = 2, .fptr = bif_assert_ne}));
     assert(add_fn(&e->fns, "halt", (struct fptr){.arity = 0, .fptr = bif_halt}));

--- a/niffy.c
+++ b/niffy.c
@@ -74,6 +74,12 @@ static term bif_element(ErlNifEnv *env, int UNUSED, const term argv[])
 }
 
 
+static term bif_halt(ErlNifEnv *UNUSED, int UNUSED, const term *UNUSED)
+{
+    exit(0);
+}
+
+
 static term bif_assert_eq(ErlNifEnv *UNUSED, int UNUSED, const term argv[])
 {
     if (enif_is_identical(argv[0], argv[1]))
@@ -97,12 +103,6 @@ static term bif_assert_ne(ErlNifEnv *UNUSED, int UNUSED, const term argv[])
     pretty_print_term(stderr, &argv[1]);
     fputc('\n', stderr);
     abort();
-}
-
-
-static term bif_halt(ErlNifEnv *UNUSED, int UNUSED, const term *UNUSED)
-{
-    exit(0);
 }
 
 
@@ -154,7 +154,7 @@ static bool add_fn(struct atom_ptr_map *fm, const char *s, struct fptr fn)
 }
 
 
-static struct enif_entry_t internal_env_entry = {
+static struct enif_entry_t erlang_env_entry = {
     .name = "niffy"
 };
 
@@ -164,16 +164,32 @@ void niffy_construct_erlang_env(void)
     struct enif_environment_t *e = calloc(1, sizeof(*e));
     assert(e);
     *e = (struct enif_environment_t){
-        .entry = &internal_env_entry
+        .entry = &erlang_env_entry
     };
     assert(map_insert(&modules, intern_cstr(e->entry->name), e));
 
     assert(add_fn(&e->fns, "load_nif", (struct fptr){.arity = 2, .fptr = bif_load_nif}));
+    assert(add_fn(&e->fns, "halt", (struct fptr){.arity = 0, .fptr = bif_halt}));
     assert(add_fn(&e->fns, "byte_size", (struct fptr){.arity = 1, .fptr = bif_byte_size}));
     assert(add_fn(&e->fns, "element", (struct fptr){.arity = 2, .fptr = bif_element}));
-    assert(add_fn(&e->fns, "assert_eq", (struct fptr){.arity = 2, .fptr = bif_assert_eq}));
-    assert(add_fn(&e->fns, "assert_ne", (struct fptr){.arity = 2, .fptr = bif_assert_ne}));
-    assert(add_fn(&e->fns, "halt", (struct fptr){.arity = 0, .fptr = bif_halt}));
+}
+
+
+static struct enif_entry_t assert_env_entry = {
+    .name = "assert"
+};
+
+void niffy_construct_assert_env(void)
+{
+    struct enif_environment_t *e = calloc(1, sizeof(*e));
+    assert(e);
+    *e = (struct enif_environment_t){
+        .entry = &assert_env_entry
+    };
+    assert(map_insert(&modules, intern_cstr(e->entry->name), e));
+
+    assert(add_fn(&e->fns, "eq", (struct fptr){.arity = 2, .fptr = bif_assert_eq}));
+    assert(add_fn(&e->fns, "ne", (struct fptr){.arity = 2, .fptr = bif_assert_ne}));
 }
 
 

--- a/niffy.c
+++ b/niffy.c
@@ -49,6 +49,15 @@ static term bif_load_nif(ErlNifEnv *env, int argc, const term argv[])
 }
 
 
+static term bif_byte_size(ErlNifEnv *env, int UNUSED, const term argv[])
+{
+    ErlNifBinary bin;
+    if (!enif_inspect_binary(env, argv[0], &bin))
+        return enif_make_badarg(env);
+    return enif_make_ulong(env, bin.size);
+}
+
+
 static term bif_element(ErlNifEnv *env, int UNUSED, const term argv[])
 {
     int index, arity;
@@ -160,6 +169,7 @@ void niffy_construct_erlang_env(void)
     assert(map_insert(&modules, intern_cstr(e->entry->name), e));
 
     assert(add_fn(&e->fns, "load_nif", (struct fptr){.arity = 2, .fptr = bif_load_nif}));
+    assert(add_fn(&e->fns, "byte_size", (struct fptr){.arity = 1, .fptr = bif_byte_size}));
     assert(add_fn(&e->fns, "element", (struct fptr){.arity = 2, .fptr = bif_element}));
     assert(add_fn(&e->fns, "assert_eq", (struct fptr){.arity = 2, .fptr = bif_assert_eq}));
     assert(add_fn(&e->fns, "assert_ne", (struct fptr){.arity = 2, .fptr = bif_assert_ne}));

--- a/niffy.h
+++ b/niffy.h
@@ -4,6 +4,7 @@
 #include "ast.h"
 
 extern void niffy_construct_erlang_env(void);
+extern void niffy_construct_assert_env(void);
 extern bool niffy_load_so(const char *, int, int);
 extern void niffy_handle_statement(struct statement *);
 extern void niffy_destroy_environments(void);


### PR DESCRIPTION
Implemented `niffy:byte_size/1` and `niffy:element/2` (to be able to fuzz `erlang-lz4` roundtrip), then realized it might be cleaner for the `niffy` module to mirror the `erlang` module, and have other functions elsewhere.
