### PR TITLE
Add leak test for enif_alloc_binary + enif_make_binary

### DIFF
--- a/t/clean_nif.c
+++ b/t/clean_nif.c
@@ -25,10 +25,16 @@ static ERL_NIF_TERM return_iolist_as_binary(ErlNifEnv *env, int argc, const ERL_
     return enif_make_binary(env, &bin);
 }
 
-
+static ERL_NIF_TERM alloc_and_make_binary(ErlNifEnv *env, int UNUSED, const ERL_NIF_TERM *UNUSED)
+{
+    ErlNifBinary bin;
+    enif_alloc_binary(42, &bin);
+    return enif_make_binary(env, &bin);
+}
 
 static ErlNifFunc fns[] = {
     {"return_ok", 0, return_ok},
-    {"return_iolist_as_binary", 1, return_iolist_as_binary}
+    {"return_iolist_as_binary", 1, return_iolist_as_binary},
+    {"alloc_and_make_binary", 0, alloc_and_make_binary}
 };
 ERL_NIF_INIT(clean_nif, fns, &load, NULL, NULL, NULL);

--- a/t/leak_detection.t
+++ b/t/leak_detection.t
@@ -19,6 +19,7 @@ check_clean_nif() {
     echo "# clean NIF should have no leaks"
     echo 'clean_nif:return_ok().' | quiet valgrind --leak-check=full --error-exitcode=42 ./niffy ./t/clean_nif.so
     echo 'clean_nif:return_iolist_as_binary([<<1,2,3>>, 42]).' | quiet valgrind --leak-check=full --error-exitcode=42 ./niffy ./t/clean_nif.so
+    echo 'clean_nif:alloc_and_make_binary().' | quiet valgrind --leak-check=full --error-exitcode=42 ./niffy ./t/clean_nif.so
 }
 
 check_leaky_nif() {


### PR DESCRIPTION
As discussed, this currently fails. I'm working on a fix which will most likely be about adding an `owned` bool member to the ErlNifBinary struct.