### PR TITLE
Add support for enif_{fprintf/vfprintf/snprintf/vsnprintf}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,7 @@ sudo: false
 language: erlang
 script: make check PROVEFLAGS=-v DEFINES=-DLACKS_BUILTIN_ADD_OVERFLOW
 otp_release:
-  - 17.5
-  - 18.1
-  - 18.2
-  - 18.3
-  - 19.0
+  - 21.3
 addons:
   apt:
     packages:

--- a/nif_stubs.c
+++ b/nif_stubs.c
@@ -869,6 +869,35 @@ void *enif_alloc_resource(ErlNifResourceType *UNUSED, size_t size)
     return malloc(size);
 }
 
+int enif_fprintf(FILE *filep, const char *format, ...)
+{
+    int ret;
+    va_list arglist;
+    va_start(arglist, format);
+    ret = vfprintf(filep, format, arglist);
+    va_end(arglist);
+    return ret;
+}
+
+int enif_vfprintf(FILE *filep, const char *format, va_list ap)
+{
+    return vfprintf(filep, format, ap);
+}
+
+int enif_snprintf(char *buffer, size_t size, const char *format, ...)
+{
+    int ret;
+    va_list arglist;
+    va_start(arglist, format);
+    ret = vsnprintf(buffer, size, format, arglist);
+    va_end(arglist);
+    return ret;
+}
+
+int enif_vsnprintf(char *buffer, size_t size, const char *format, va_list ap)
+{
+    return vsnprintf(buffer, size, format, ap);
+}
 
 void enif_release_resource(void *UNUSED)
 {


### PR DESCRIPTION
It won't be able to format terms using `%T` but at least it'll be able to run nifs with that have these statements, mostly when debugging I guess.